### PR TITLE
Ignore Invalid Codepoints When Parsing Fonts

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -70,7 +70,7 @@ jobs:
         run: cargo build --verbose
 
       - name: Test
-        run: cargo test --verbose
+        run: cargo test --features test-remote-fonts --verbose
 
   build-wasm:
     needs: check

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 target
 Cargo.lock
+
+*gitignore*
+!.gitignore

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name    = "bdf"
-version = "0.5.5"
+version = "0.7.0"
 edition = "2018"
 
 authors = ["meh. <meh@schizofreni.co>"]
@@ -10,6 +10,16 @@ description = "BDF format handling."
 repository  = "https://github.com/meh/rust-bdf"
 keywords    = ["font", "bdf"]
 
+[features]
+default = []
+
+# This feature is used for testing only and allows downloading fonts from GitHub
+# to use as parsing test-cases
+test-remote-fonts = []
+
 [dependencies]
-bit-set = "0.3"
+bit-set = "0.5.2"
 thiserror = "1.0.20"
+
+[dev-dependencies]
+reqwest = { version = "0.11.3", features = ["blocking"] }

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,24 +10,51 @@ pub enum Error {
     IO(#[from] io::Error),
 
     /// A downstream parsing error.
-    #[error("{0}")]
-    Parse(#[from] num::ParseIntError),
+    #[error("{error} on line {line_number}: `{line}`")]
+    Parse {
+        /// The parser error
+        error: num::ParseIntError,
+        /// The line number in the font file this was encountered on
+        line_number: u32,
+        /// The contents of the line that this error was encountered on
+        line: String,
+    },
 
     /// `STARTFONT` is missing the format version.
-    #[error("Missing version from STARTFONT")]
-    MissingVersion,
+    #[error("Missing version from STARTFONT on line {line_number}: {line}")]
+    MissingVersion {
+        /// The line number in the font file this was encountered on
+        line_number: u32,
+        /// The contents of the line that this error was encountered on
+        line: String,
+    },
 
     /// There was no bounding box for a character.
-    #[error("Missing bounding box")]
-    MissingBoundingBox,
+    #[error("Missing bounding box on line {line_number}: {line}")]
+    MissingBoundingBox {
+        /// The line number in the font file this was encountered on
+        line_number: u32,
+        /// The contents of the line that this error was encountered on
+        line: String,
+    },
 
     /// An entry is missing a value.
-    #[error("Missing value for property")]
-    MissingValue(String),
+    #[error("Missing value for property `{property_name}` on line {line_number}")]
+    MissingValue {
+        /// The name of the property that was missing a value
+        property_name: String,
+        /// The contents of the line that this error was encountered on
+        line_number: u32,
+    },
 
     /// An unknown error.
     #[error("An invalid codepoint has been found")]
-    InvalidCodepoint,
+    InvalidCodepoint {
+        /// The line number in the font file this was encountered on
+        line_number: u32,
+        /// The contents of the line that this error was encountered on
+        line: String,
+    },
 
     /// Eof has been reached.
     #[error("End of file reached")]

--- a/tests/lib.rs
+++ b/tests/lib.rs
@@ -1,9 +1,38 @@
 extern crate bdf;
 
 #[test]
-fn open() {
+fn open_gohufont_font() {
     let font = bdf::open("tests/gohufont.bdf").unwrap();
+    assert_eq!(font.format(), "2.1");
+}
 
+#[cfg(feature = "test-remote-fonts")]
+#[test]
+fn open_cozette_font() {
+    // Test the Cozette font
+    let font_data = reqwest::blocking::get(
+        "https://github.com/slavfox/Cozette/releases/download/v.1.9.3/cozette.bdf",
+    )
+    .unwrap()
+    .text()
+    .unwrap();
+
+    let font = bdf::read(font_data.as_bytes()).unwrap();
+    assert_eq!(font.format(), "2.1");
+}
+
+#[cfg(feature = "test-remote-fonts")]
+#[test]
+fn open_zpix_font() {
+    // Test the zpix font
+    let font_data = reqwest::blocking::get(
+        "https://github.com/SolidZORO/zpix-pixel-font/releases/download/v3.1.6/zpix.bdf",
+    )
+    .unwrap()
+    .text()
+    .unwrap();
+
+    let font = bdf::read(font_data.as_bytes()).unwrap();
     assert_eq!(font.format(), "2.1");
 }
 


### PR DESCRIPTION
- Add file position info to some parser error variants
- Add optional tests that download fonts to test parser compatibility
- Increment cargo version