### PR TITLE
Allow comments that do not use quotes (and are 1 character long)

### DIFF
--- a/src/property.rs
+++ b/src/property.rs
@@ -23,13 +23,43 @@ impl Property {
 }
 
 #[inline]
+fn strip_quotes(string: &str) -> Option<&str> {
+    string.trim().strip_prefix('"')?.strip_suffix('"')
+}
+
+#[inline]
 pub fn extract(string: &str) -> String {
-    (&string[1..string.len() - 1]).replace("\"\"", "\"")
+    match strip_quotes(string) {
+        Some(s) => s.replace("\"\"", "\""),
+        None => string.to_owned(),
+    }
 }
 
 #[cfg(test)]
 mod test {
     use super::*;
+
+    #[test]
+    fn extract_string() {
+        // no surrounding quotes
+        assert_eq!(
+            "test".to_string(),
+            extract(r#"test"#)
+        );
+        assert_eq!(
+            r#"test"""#.to_string(),
+            extract(r#"test"""#)
+        );
+        // surrounding quotes
+        assert_eq!(
+            "hello".to_string(),
+            extract(r#""hello""#)
+        );
+        assert_eq!(
+            r#"this is a "test""#.to_string(),
+            extract(r#""this is a ""test""""#)
+        );
+    }
 
     #[test]
     fn parse_property() {
@@ -40,6 +70,10 @@ mod test {
         assert_eq!(
             Property::String("Hello World".into()),
             Property::parse(r#"Hello World"#)
+        );
+        assert_eq!(
+            Property::String(r#""Hello"World""#.into()),
+            Property::parse(r#"""Hello""World"""#)
         );
         assert_eq!(Property::Integer(41), Property::parse(r#"41"#));
         assert_eq!(Property::String("41".into()), Property::parse(r#""41""#));


### PR DESCRIPTION
I am using this library to load the font [bitocra](https://github.com/ninjaaron/bitocra) and i got a panic when using rust-bdf 0.6.0 or the version on master (specifically commit 2eceb6634bf4932cc877a69d574c86994c0cf883):
```
panicked at 'begin <= end (1 <= 0) when slicing `1`', /home/nya/.cargo/git/checkouts/rust-bdf-3a5c33942eb64007/2eceb66/src/property.rs:27:7
```

This is because the font uses `COMMENT`s without surrounding quotes and one of the comments is just one character long:
https://github.com/ninjaaron/bitocra/blob/223d56ac5ea62546c5679c41fd486c463b6a5b17/bitocra.bdf#L4

I ended up changing the `extract` function in `property.rs` to be able to load that font:
Surrounding quotes are only removed if they are present after trimming the content and `""` are only replaced by `"` if that was the case.
This means that strings that are not surrounded by quotes are just kept as-is, similar to what `Property::parse` already does:
https://github.com/meh/rust-bdf/blob/2eceb6634bf4932cc877a69d574c86994c0cf883/src/property.rs#L15-L21
But when it comes to `COMMENT`s this check was not performed:
https://github.com/meh/rust-bdf/blob/2eceb6634bf4932cc877a69d574c86994c0cf883/src/reader/reader.rs#L59

I also saw issue #12 and if my changes are merged, then i would be okay with the project changing its license to MIT and/or Apache-2.0, or the Unlicense in the future.